### PR TITLE
Servicios (hub) + 5 páginas detalle (PDF-only) — español, a11y y rendimiento.

### DIFF
--- a/capacitacion-dc3.html
+++ b/capacitacion-dc3.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Servicios - GyG Protección Civil</title>
-  <meta name="description" content="Servicios de GyG: Protección Civil, Capacitación con constancia DC3, Dictámenes e Inspecciones, STPS, y Venta de equipos y señalética.">
+  <title>Capacitación DC3 - GyG</title>
+  <meta name="description" content="Cursos de incendios, primeros auxilios y evacuación. Constancia DC3 con validez ante STPS y Protección Civil.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,59 +39,44 @@
 
     <section class="py-5">
       <div class="container">
-        <h1 class="mb-4">Servicios</h1>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Protección Civil</h2>
-                <p class="card-text">Programas internos, estudios de riesgo y planes de emergencia.</p>
-                <a href="proteccion-civil.html" class="btn btn-primary" aria-label="Ver detalles de Protección Civil">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Capacitación (constancia DC3)</h2>
-                <p class="card-text">Cursos de incendios, primeros auxilios y evacuación con constancia DC3.</p>
-                <a href="capacitacion-dc3.html" class="btn btn-primary" aria-label="Ver detalles de Capacitación DC3">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Dictámenes e Inspecciones</h2>
-                <p class="card-text">Dictamen estructural y de instalaciones, inspecciones y simulacros.</p>
-                <a href="dictamenes-inspecciones.html" class="btn btn-primary" aria-label="Ver detalles de Dictámenes e Inspecciones">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Seguridad y Salud en el Trabajo (STPS)</h2>
-                <p class="card-text">Diagnósticos y programas por NOM para seguridad y salud laboral.</p>
-                <a href="stps.html" class="btn btn-primary" aria-label="Ver detalles de Seguridad y Salud en el Trabajo">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Venta de Insumos y Equipamiento</h2>
-                <p class="card-text">Extintores, señalética y equipo de emergencia y rescate.</p>
-                <a href="equipos-y-senaletica.html" class="btn btn-primary" aria-label="Ver detalles de Venta de Insumos y Equipamiento">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <h1>Capacitación (constancia DC3)</h1>
+        <h2>Temas / Modalidades</h2>
+        <ul>
+          <li>Combate de incendios (básico–avanzado) con laboratorio del fuego</li>
+          <li>Primeros Auxilios (con DEA y protocolos AHA/ARC)</li>
+          <li>Evacuación (sismos, incendios, delincuencia organizada, fugas, volcánicos, concentraciones masivas)</li>
+          <li>Búsqueda y rescate</li>
+          <li>Triage (extra e intra hospitalario)</li>
+          <li>Comando de Incidentes (NDLSF)</li>
+        </ul>
+        <h2>Validez</h2>
+        <ul>
+          <li>Expedición de constancia DC3 con validez ante STPS y Protección Civil</li>
+        </ul>
+        <a href="contacto.html?tipo=capacitacion" class="btn btn-primary mt-3" aria-label="Cotizar capacitación DC3">Cotizar capacitación DC3</a>
       </div>
     </section>
-  </main>
 
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2>Agenda/Modalidades</h2>
+        <p>Información disponible próximamente.</p>
+      </div>
+    </section>
+
+    <section class="py-5">
+      <div class="container">
+        <h2>Otros servicios</h2>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
   <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-

--- a/dictamenes-inspecciones.html
+++ b/dictamenes-inspecciones.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Servicios - GyG Protección Civil</title>
-  <meta name="description" content="Servicios de GyG: Protección Civil, Capacitación con constancia DC3, Dictámenes e Inspecciones, STPS, y Venta de equipos y señalética.">
+  <title>Dictámenes e Inspecciones - GyG</title>
+  <meta name="description" content="Dictamen estructural y de instalaciones. Inspecciones de seguridad, simulacros y protocolos para eventos especiales.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,59 +39,34 @@
 
     <section class="py-5">
       <div class="container">
-        <h1 class="mb-4">Servicios</h1>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Protección Civil</h2>
-                <p class="card-text">Programas internos, estudios de riesgo y planes de emergencia.</p>
-                <a href="proteccion-civil.html" class="btn btn-primary" aria-label="Ver detalles de Protección Civil">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Capacitación (constancia DC3)</h2>
-                <p class="card-text">Cursos de incendios, primeros auxilios y evacuación con constancia DC3.</p>
-                <a href="capacitacion-dc3.html" class="btn btn-primary" aria-label="Ver detalles de Capacitación DC3">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Dictámenes e Inspecciones</h2>
-                <p class="card-text">Dictamen estructural y de instalaciones, inspecciones y simulacros.</p>
-                <a href="dictamenes-inspecciones.html" class="btn btn-primary" aria-label="Ver detalles de Dictámenes e Inspecciones">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Seguridad y Salud en el Trabajo (STPS)</h2>
-                <p class="card-text">Diagnósticos y programas por NOM para seguridad y salud laboral.</p>
-                <a href="stps.html" class="btn btn-primary" aria-label="Ver detalles de Seguridad y Salud en el Trabajo">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Venta de Insumos y Equipamiento</h2>
-                <p class="card-text">Extintores, señalética y equipo de emergencia y rescate.</p>
-                <a href="equipos-y-senaletica.html" class="btn btn-primary" aria-label="Ver detalles de Venta de Insumos y Equipamiento">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <h1>Dictámenes e Inspecciones</h1>
+        <h2>Alcance</h2>
+        <ul>
+          <li>Dictamen estructural, instalaciones eléctricas y de gas</li>
+          <li>Visto bueno de seguridad</li>
+          <li>Inspecciones: extintores, sistemas contra incendio, condiciones de seguridad</li>
+          <li>Simulacros</li>
+          <li>Atención de inspecciones STPS y Protección Civil</li>
+          <li>Integración CLAM</li>
+          <li>Protocolos de seguridad para eventos especiales</li>
+        </ul>
+        <a href="contacto.html?tipo=inspecciones" class="btn btn-primary mt-3" aria-label="Solicitar evaluación">Solicitar evaluación</a>
       </div>
     </section>
-  </main>
 
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2>Otros servicios</h2>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (constancia DC3)</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
   <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-

--- a/equipos-y-senaletica.html
+++ b/equipos-y-senaletica.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Servicios - GyG Protección Civil</title>
-  <meta name="description" content="Servicios de GyG: Protección Civil, Capacitación con constancia DC3, Dictámenes e Inspecciones, STPS, y Venta de equipos y señalética.">
+  <title>Venta de Insumos y Equipamiento - GyG</title>
+  <meta name="description" content="Extintores, señalética y equipos de emergencia, búsqueda y rescate.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,59 +39,34 @@
 
     <section class="py-5">
       <div class="container">
-        <h1 class="mb-4">Servicios</h1>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Protección Civil</h2>
-                <p class="card-text">Programas internos, estudios de riesgo y planes de emergencia.</p>
-                <a href="proteccion-civil.html" class="btn btn-primary" aria-label="Ver detalles de Protección Civil">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Capacitación (constancia DC3)</h2>
-                <p class="card-text">Cursos de incendios, primeros auxilios y evacuación con constancia DC3.</p>
-                <a href="capacitacion-dc3.html" class="btn btn-primary" aria-label="Ver detalles de Capacitación DC3">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Dictámenes e Inspecciones</h2>
-                <p class="card-text">Dictamen estructural y de instalaciones, inspecciones y simulacros.</p>
-                <a href="dictamenes-inspecciones.html" class="btn btn-primary" aria-label="Ver detalles de Dictámenes e Inspecciones">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Seguridad y Salud en el Trabajo (STPS)</h2>
-                <p class="card-text">Diagnósticos y programas por NOM para seguridad y salud laboral.</p>
-                <a href="stps.html" class="btn btn-primary" aria-label="Ver detalles de Seguridad y Salud en el Trabajo">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Venta de Insumos y Equipamiento</h2>
-                <p class="card-text">Extintores, señalética y equipo de emergencia y rescate.</p>
-                <a href="equipos-y-senaletica.html" class="btn btn-primary" aria-label="Ver detalles de Venta de Insumos y Equipamiento">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <h1>Venta de Insumos y Equipamiento</h1>
+        <h2>Catálogo</h2>
+        <ul>
+          <li>Extintores, gabinetes, sistemas fijos, accesorios de hidrantes</li>
+          <li>Señalamientos (señalética)</li>
+          <li>Trajes de bombero y Haz-Mat</li>
+          <li>Botiquines, equipo prehospitalario, aire autónomo, detectores</li>
+          <li>EPP y chalecos</li>
+          <li>Equipos de búsqueda y rescate</li>
+          <li>Traslado de pacientes (terrestre/aéreo)</li>
+        </ul>
+        <a href="contacto.html?tipo=equipos" class="btn btn-primary mt-3" aria-label="Solicitar cotización">Solicitar cotización</a>
       </div>
     </section>
-  </main>
 
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2>Otros servicios</h2>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (constancia DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
   <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-

--- a/proteccion-civil.html
+++ b/proteccion-civil.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Servicios - GyG Protección Civil</title>
-  <meta name="description" content="Servicios de GyG: Protección Civil, Capacitación con constancia DC3, Dictámenes e Inspecciones, STPS, y Venta de equipos y señalética.">
+  <title>Protección Civil - GyG</title>
+  <meta name="description" content="Programas internos, estudios de riesgo y planes de emergencia. Rutas, señalética, RSIP y comités internos.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,59 +39,49 @@
 
     <section class="py-5">
       <div class="container">
-        <h1 class="mb-4">Servicios</h1>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Protección Civil</h2>
-                <p class="card-text">Programas internos, estudios de riesgo y planes de emergencia.</p>
-                <a href="proteccion-civil.html" class="btn btn-primary" aria-label="Ver detalles de Protección Civil">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Capacitación (constancia DC3)</h2>
-                <p class="card-text">Cursos de incendios, primeros auxilios y evacuación con constancia DC3.</p>
-                <a href="capacitacion-dc3.html" class="btn btn-primary" aria-label="Ver detalles de Capacitación DC3">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Dictámenes e Inspecciones</h2>
-                <p class="card-text">Dictamen estructural y de instalaciones, inspecciones y simulacros.</p>
-                <a href="dictamenes-inspecciones.html" class="btn btn-primary" aria-label="Ver detalles de Dictámenes e Inspecciones">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Seguridad y Salud en el Trabajo (STPS)</h2>
-                <p class="card-text">Diagnósticos y programas por NOM para seguridad y salud laboral.</p>
-                <a href="stps.html" class="btn btn-primary" aria-label="Ver detalles de Seguridad y Salud en el Trabajo">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Venta de Insumos y Equipamiento</h2>
-                <p class="card-text">Extintores, señalética y equipo de emergencia y rescate.</p>
-                <a href="equipos-y-senaletica.html" class="btn btn-primary" aria-label="Ver detalles de Venta de Insumos y Equipamiento">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <h1>Protección Civil</h1>
+        <h2>Qué incluye</h2>
+        <ul>
+          <li>Programas internos (institucional/empresarial/industrial/escolar)</li>
+          <li>Carta de corresponsabilidad (12 meses)</li>
+          <li>Estudios: incendio; riesgos internos/externos; grado de riesgo; vulnerabilidad</li>
+          <li>Planes de emergencia</li>
+          <li>Cronogramas y bitácoras</li>
+          <li>Rutas y señalética</li>
+          <li>RSIP (recipientes sujetos a presión)</li>
+          <li>Riesgo en maquinaria/instalaciones</li>
+          <li>Detección de necesidades de capacitación</li>
+          <li>Estudio de impacto / tramitología ambiental</li>
+          <li>Comités internos</li>
+        </ul>
+        <a href="contacto.html?tipo=diagnostico" class="btn btn-primary mt-3" aria-label="Solicitar diagnóstico de cumplimiento">Solicitar diagnóstico de cumplimiento</a>
       </div>
     </section>
-  </main>
 
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2>Proceso</h2>
+        <p>Información disponible próximamente.</p>
+        <h2>Entregables</h2>
+        <p>Información disponible próximamente.</p>
+        <h2>FAQs</h2>
+        <p>Información disponible próximamente.</p>
+      </div>
+    </section>
+
+    <section class="py-5">
+      <div class="container">
+        <h2>Otros servicios</h2>
+        <ul>
+          <li><a href="capacitacion-dc3.html">Capacitación (constancia DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
   <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-

--- a/stps.html
+++ b/stps.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Servicios - GyG Protección Civil</title>
-  <meta name="description" content="Servicios de GyG: Protección Civil, Capacitación con constancia DC3, Dictámenes e Inspecciones, STPS, y Venta de equipos y señalética.">
+  <title>Seguridad y Salud en el Trabajo (STPS) - GyG</title>
+  <meta name="description" content="Diagnósticos y programas por NOM. Capacitación normativa para seguridad y salud laboral.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,59 +39,30 @@
 
     <section class="py-5">
       <div class="container">
-        <h1 class="mb-4">Servicios</h1>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Protección Civil</h2>
-                <p class="card-text">Programas internos, estudios de riesgo y planes de emergencia.</p>
-                <a href="proteccion-civil.html" class="btn btn-primary" aria-label="Ver detalles de Protección Civil">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Capacitación (constancia DC3)</h2>
-                <p class="card-text">Cursos de incendios, primeros auxilios y evacuación con constancia DC3.</p>
-                <a href="capacitacion-dc3.html" class="btn btn-primary" aria-label="Ver detalles de Capacitación DC3">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Dictámenes e Inspecciones</h2>
-                <p class="card-text">Dictamen estructural y de instalaciones, inspecciones y simulacros.</p>
-                <a href="dictamenes-inspecciones.html" class="btn btn-primary" aria-label="Ver detalles de Dictámenes e Inspecciones">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Seguridad y Salud en el Trabajo (STPS)</h2>
-                <p class="card-text">Diagnósticos y programas por NOM para seguridad y salud laboral.</p>
-                <a href="stps.html" class="btn btn-primary" aria-label="Ver detalles de Seguridad y Salud en el Trabajo">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-          <div class="col">
-            <div class="card h-100">
-              <div class="card-body">
-                <h2 class="h5">Venta de Insumos y Equipamiento</h2>
-                <p class="card-text">Extintores, señalética y equipo de emergencia y rescate.</p>
-                <a href="equipos-y-senaletica.html" class="btn btn-primary" aria-label="Ver detalles de Venta de Insumos y Equipamiento">Ver detalles</a>
-              </div>
-            </div>
-          </div>
-        </div>
+        <h1>Seguridad y Salud en el Trabajo (STPS)</h1>
+        <h2>Qué ofrecemos</h2>
+        <ul>
+          <li>Diagnósticos específicos e integrales</li>
+          <li>Desarrollo e implementación de programas, procedimientos e instrucciones por NOM</li>
+          <li>Capacitación normativa por proceso</li>
+        </ul>
+        <a href="contacto.html?tipo=stps" class="btn btn-primary mt-3" aria-label="Solicitar diagnóstico">Solicitar diagnóstico</a>
       </div>
     </section>
-  </main>
 
+    <section class="py-5 bg-light">
+      <div class="container">
+        <h2>Otros servicios</h2>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (constancia DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+      </div>
+    </section>
+
+  </main>
   <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- Corrige ruta CSS y añade meta descripción en `servicios.html`.
- Crea hub de servicios con 5 tarjetas enlazadas a páginas de detalle.
- Agrega páginas de detalle para Protección Civil, Capacitación DC3, Dictámenes e Inspecciones, STPS y Venta de Insumos, incluyendo bullets del PDF y CTAs.
- Añade meta descriptions y bloque “Otros servicios” en cada página. JS diferido para mejor rendimiento.

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68938d601e98833287f1fab3e9689c92