### PR TITLE
Sectores/Industrias + Certificaciones + Casos (PDF-only) — español, a11y y SEO mínimo

### DIFF
--- a/casos.html
+++ b/casos.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="Lista textual de clientes representativos según el documento de GyG.">
   <title>Casos y Clientes - GyG Protección Civil</title>
-  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
   </style>
@@ -39,12 +40,113 @@
     <section class="py-5">
       <div class="container">
         <h1>Casos y Clientes</h1>
-        <ul class="list-unstyled"></ul>
+        <div class="mb-3">
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="todos" aria-pressed="true">Todos</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="retail">Retail</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="hoteles">Hoteles/Eventos</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="educacion">Educación</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="gobierno">Gobierno</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="salud">Salud</button>
+          <button type="button" class="btn btn-sm btn-outline-primary me-2" data-filter="energia">Energía</button>
+          <button type="button" class="btn btn-sm btn-outline-primary" data-filter="manufactura">Manufactura</button>
+        </div>
+        <ul class="list-unstyled">
+          <li data-sector="retail">CENTRO COMERCIAL EL PASEO TEHUACAN</li>
+          <li data-sector="manufactura">BOXMARK LEATHER DE MEXICO S.A. DE C.V.(PROVEEDOR DE AUDI)</li>
+          <li data-sector="hoteles">HOTEL CITY EXPRESS TEHUACAN</li>
+          <li data-sector="hoteles">CINEPOLIS TEHUACAN</li>
+          <li data-sector="manufactura">BACHOCO</li>
+          <li data-sector="retail">FAMSA</li>
+          <li data-sector="manufactura">PEPSICO</li>
+          <li data-sector="manufactura">HELLMAN WORL WIDE</li>
+          <li data-sector="retail">FARMACIAS SIMILARES (BOTICARIOS DEL PUEBLO)</li>
+          <li data-sector="retail">ROCKETO</li>
+          <li data-sector="hoteles">FIA FEDERACION INTENACIONAL DE AUTOMOVILISMO (COBERTURA SAFETY EN EVENTOS INTERNACIONALES, FORMULA 1, FORMULA E, WORLD ENDURANCE CHAMPIONSHIP)</li>
+          <li data-sector="retail">GRUPO EXCELENCIA (AGENCIAS: NISSAN, RENAULT, HONDA, KIA)</li>
+          <li data-sector="hoteles">JACKPOT TEHUACAN (CORPORATIVOO CODERE HIPÓDROMO DE LAS AMERICAS)</li>
+          <li data-sector="hoteles">WINPOT CASINO LA NORIA PUEBLA (CORPORATIVO PUR UMAZAL TOV)</li>
+          <li data-sector="manufactura">LABORATORIO AVIMEX ASESOR DEL CORPORATIVO A NIVEL NACIONAL</li>
+          <li data-sector="otros">PROMOTORA DE PERSONAL D.F.</li>
+          <li data-sector="hoteles">MVS ASESOR DE EVENTOS MASIVOS A NIVEL NACIONAL</li>
+          <li data-sector="hoteles">HARLEY DAVIDSON PUEBLA ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li data-sector="hoteles">APODACA GROUP ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li data-sector="hoteles">OCESA ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li data-sector="educacion">UNIVERSIDAD INTERAMERICANA PARA EL DESARROLLO (UNID) CAMPUS TEHUACAN</li>
+          <li data-sector="educacion">UNIDAD ESCOLAR LIC. BENITO JUAREZ CAMPUS TEHUACAN Y PUEBLA</li>
+          <li data-sector="educacion">INSTITUTO CULINARIO BOULANGER PUEBLA</li>
+          <li data-sector="manufactura">MINERA SANTA MONICA IZUCAR DE MATAMOROS</li>
+          <li data-sector="hoteles">HOTEL CASA CANTARRANAS TEHUACAN</li>
+          <li data-sector="hoteles">HOTEL VILLA BLANCA TEHUACAN</li>
+          <li data-sector="hoteles">HOTEL MONROY TEHUACAN</li>
+          <li data-sector="hoteles">HOTEL MONIETT TEHUACAN</li>
+          <li data-sector="manufactura">COSTURAS Y MANUFACTURAS DE TLAXCALA S. DE R.L. DE C.V. PLANTA TEHUACAN</li>
+          <li data-sector="salud">SERVCIOS DE ATENCION Y CUIDADO INFANTIL A NIVEL ESTADO</li>
+          <li data-sector="gobierno">CAICS DEPENDIENTES DEL DIF ESTATAL A NIVEL ESTADO</li>
+          <li data-sector="retail">CADENA DE RESTAURANTES BRAZILIAN ASESOR DEL CORPORTIVO A NIVEL NACIONAL</li>
+          <li data-sector="retail">HAPPY LAND ANTES DIVERSIONES MOY TEHUACAN</li>
+          <li data-sector="retail">BURGER KING TEHUACAN</li>
+          <li data-sector="manufactura">GEOMETRIKA DE GRUPO EXCEL NOBLEZA</li>
+          <li data-sector="manufactura">MANUFACTURA, DESARROLLO DIGITAL Y PROCESOS INDUSTRIALES S.A. DE C.V.</li>
+          <li data-sector="gobierno">H. AYUNTAMIENTO DE TEHUACAN</li>
+          <li data-sector="gobierno">H. AYUNTAMIENTO DE COXCALTLAN</li>
+          <li data-sector="retail">SCALA DISTRITO SONATA</li>
+          <li data-sector="gobierno">FINANCIERA NACIONAL DE DESARROLLO AGROPECUARIO, RURAL, FORESTAL Y PESQUERO (FND)</li>
+          <li data-sector="educacion">INSTITUTO ARNOLD GESELL</li>
+          <li data-sector="educacion">COLEGIO MARIA TERESA LOPEZ VIUDA DE TELLEZ</li>
+          <li data-sector="educacion">CENTRO DE ESTUDIO KENNEDY</li>
+          <li data-sector="educacion">COLEGIO DISCOVERY</li>
+          <li data-sector="educacion">INTITUTO D’VINCI</li>
+          <li data-sector="educacion">INSTITUTO EDUCARES</li>
+          <li data-sector="energia">ESTACIÓN DE SERVICIO OXI FUELL</li>
+          <li data-sector="energia">GASOLINERA PEÑAFIEL</li>
+          <li data-sector="energia">ESTACIÓN DE SERVICIO SOCORRO ROMERO SANCHEZ</li>
+          <li data-sector="energia">GASOLINERA EL RIEGO</li>
+          <li data-sector="hoteles">HOTELES ONE PUEBLA</li>
+          <li data-sector="salud">IMSS RED DE GUARDERIAS</li>
+          <li data-sector="salud">CENTRO MEDICO ESPERANZA</li>
+          <li data-sector="gobierno">CIUDAD MODELO GOBIERNO DEL ESTADO DE PUEBLA</li>
+          <li data-sector="otros">FINAGAM</li>
+          <li data-sector="retail">OFFICE DEPOT</li>
+          <li data-sector="retail">RADIO SHACK</li>
+          <li data-sector="retail">INBURSA</li>
+          <li data-sector="otros">TELMEX</li>
+          <li data-sector="gobierno">MUNICIPIO DE ZINACATEPEC</li>
+          <li data-sector="gobierno">BIOSFERA TEHUACAN CUICATLAN</li>
+          <li data-sector="otros">ASA TEHUACAN</li>
+          <li data-sector="retail">COPIZZA S DE R.L DE C.V (LITTLE CAESARS PIZZAS)</li>
+          <li data-sector="otros">GRUAS Y MANIOBRAS OSCARIN</li>
+          <li data-sector="otros">GRUAS OLIVIER</li>
+          <li data-sector="manufactura">GRUPO LUIN FARMACEUTICA</li>
+          <li data-sector="gobierno">GOBIERNO FEDERAL</li>
+          <li data-sector="otros">FINSOL</li>
+          <li data-sector="manufactura">CONSERFLOW</li>
+          <li data-sector="otros">GRUPO RADIORAMA</li>
+          <li data-sector="educacion">ISIMA</li>
+          <li data-sector="otros">AAOCSA</li>
+          <li data-sector="salud">VALLE DE LOS ANGELES GRUPO FUNERARIO</li>
+          <li data-sector="otros">GRUPO MAZARA</li>
+        </ul>
+        <p class="text-muted mt-3">*Lista textual tomada del documento proporcionado por GyG. No se incluyen marcas adicionales.</p>
       </div>
-    </section>
+  </section>
   </main>
 
-  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+  <script defer>
+    document.addEventListener('DOMContentLoaded', function () {
+      const buttons = document.querySelectorAll('[data-filter]');
+      const items = document.querySelectorAll('ul.list-unstyled li');
+      buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          buttons.forEach(b => b.setAttribute('aria-pressed', b === btn ? 'true' : 'false'));
+          const sector = btn.getAttribute('data-filter');
+          items.forEach(li => {
+            li.hidden = sector !== 'todos' && li.getAttribute('data-sector') !== sector;
+          });
+        });
+      });
+    });
+  </script>
+  <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
 

--- a/certificaciones.html
+++ b/certificaciones.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="Certificaciones y acreditaciones de GyG: SINAPROCI, STPS, CANACINTRA, COPARMEX, DGPCEP, UOMPCPUE.">
   <title>Certificaciones - GyG Protección Civil</title>
-  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
   </style>
@@ -36,36 +37,63 @@
       </div>
     </nav>
 
-    <section id="sinaproci" class="py-5">
+    <section class="py-5">
+      <div class="container">
+        <h1>Certificaciones y Acreditaciones</h1>
+        <p>Lista de registros y afiliaciones de GyG.</p>
+      </div>
+    </section>
+
+    <section id="sinaproci" class="py-5 bg-light">
       <div class="container">
         <h2>SINAPROCI</h2>
-        <p>Información disponible próximamente.</p>
+        <p>Registro en el Sistema Nacional de Protección Civil.</p>
+        <p class="text-muted">21-C-0177</p>
       </div>
     </section>
 
-    <section id="stps" class="py-5 bg-light">
+    <section id="stps" class="py-5">
       <div class="container">
         <h2>STPS</h2>
-        <p>Información disponible próximamente.</p>
+        <p>Registro ante la Secretaría del Trabajo y Previsión Social.</p>
+        <p class="text-muted">GOGL-690914-4DO-0005</p>
       </div>
     </section>
 
-    <section id="canacintra" class="py-5">
+    <section id="canacintra" class="py-5 bg-light">
       <div class="container">
         <h2>CANACINTRA</h2>
-        <p>Información disponible próximamente.</p>
+        <p>Afiliación a la Cámara Nacional de la Industria de Transformación.</p>
+        <p class="text-muted">03/0101/06</p>
       </div>
     </section>
 
-    <section id="coparmex" class="py-5 bg-light">
+    <section id="coparmex" class="py-5">
       <div class="container">
         <h2>COPARMEX</h2>
-        <p>Información disponible próximamente.</p>
+        <p>Afiliación a la Confederación Patronal de la República Mexicana.</p>
+        <p class="text-muted">T030119217</p>
+      </div>
+    </section>
+
+    <section id="dgpcep" class="py-5 bg-light">
+      <div class="container">
+        <h2>Reg. DGPCEP</h2>
+        <p>Registro ante la Dirección General de Protección Civil del Estado de Puebla.</p>
+        <p class="text-muted">033/DGPC/2020</p>
+      </div>
+    </section>
+
+    <section id="uompcpue" class="py-5">
+      <div class="container">
+        <h2>Reg. UOMPCPUE</h2>
+        <p>Registro de Unidad de Observancia / Protección Civil Puebla.</p>
+        <p class="text-muted">UOMPC-RAC-089/2019</p>
       </div>
     </section>
   </main>
 
-  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+  <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
 

--- a/industrias.html
+++ b/industrias.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="Servicios aplicados a sectores como retail, hotelería y eventos, educación, gobierno, salud, energía y manufactura.">
   <title>Industrias - GyG Protección Civil</title>
-  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
   </style>
@@ -39,12 +40,189 @@
     <section class="py-5">
       <div class="container">
         <h1>Industrias</h1>
-        <p>Próximamente se listarán los sectores atendidos.</p>
+        <p>GyG aplica sus servicios a múltiples sectores para fortalecer la seguridad.</p>
+        <ul class="nav flex-column flex-sm-row gap-2 mt-4">
+          <li class="nav-item"><a class="nav-link" href="#retail-comercial">Retail/Comercial</a></li>
+          <li class="nav-item"><a class="nav-link" href="#hoteles-casinos-eventos">Hoteles/Casinos/Eventos</a></li>
+          <li class="nav-item"><a class="nav-link" href="#educacion">Educación</a></li>
+          <li class="nav-item"><a class="nav-link" href="#gobierno">Gobierno</a></li>
+          <li class="nav-item"><a class="nav-link" href="#salud">Salud</a></li>
+          <li class="nav-item"><a class="nav-link" href="#energia-estaciones">Energía/Estaciones de servicio</a></li>
+          <li class="nav-item"><a class="nav-link" href="#manufactura-industrial">Manufactura/Industrial</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="retail-comercial" class="py-5 bg-light">
+      <div class="container">
+        <h2>Retail/Comercial</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>CENTRO COMERCIAL EL PASEO TEHUACAN</li>
+          <li>FAMSA</li>
+          <li>FARMACIAS SIMILARES (BOTICARIOS DEL PUEBLO)</li>
+          <li>BURGER KING TEHUACAN</li>
+          <li>OFFICE DEPOT</li>
+          <li>RADIO SHACK</li>
+          <li>SCALA DISTRITO SONATA</li>
+          <li>COPIZZA S DE R.L DE C.V (LITTLE CAESARS PIZZAS)</li>
+          <li>HAPPY LAND ANTES DIVERSIONES MOY TEHUACAN</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="hoteles-casinos-eventos" class="py-5">
+      <div class="container">
+        <h2>Hoteles/Casinos/Eventos</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>HOTEL CITY EXPRESS TEHUACAN</li>
+          <li>HOTEL CASA CANTARRANAS TEHUACAN</li>
+          <li>HOTEL VILLA BLANCA TEHUACAN</li>
+          <li>HOTEL MONROY TEHUACAN</li>
+          <li>HOTEL MONIETT TEHUACAN</li>
+          <li>JACKPOT TEHUACAN (CORPORATIVOO CODERE HIPÓDROMO DE LAS AMERICAS)</li>
+          <li>WINPOT CASINO LA NORIA PUEBLA (CORPORATIVO PUR UMAZAL TOV)</li>
+          <li>OCESA ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li>APODACA GROUP ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li>MVS ASESOR DE EVENTOS MASIVOS A NIVEL NACIONAL</li>
+          <li>HARLEY DAVIDSON PUEBLA ASESOR Y OPERADOR DE EVENTOS MASIVOS</li>
+          <li>FIA FEDERACION INTENACIONAL DE AUTOMOVILISMO (COBERTURA SAFETY EN EVENTOS INTERNACIONALES, FORMULA 1, FORMULA E, WORLD ENDURANCE CHAMPIONSHIP)</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="educacion" class="py-5 bg-light">
+      <div class="container">
+        <h2>Educación</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>UNIVERSIDAD INTERAMERICANA PARA EL DESARROLLO (UNID) CAMPUS TEHUACAN</li>
+          <li>UNIDAD ESCOLAR LIC. BENITO JUAREZ CAMPUS TEHUACAN Y PUEBLA</li>
+          <li>INSTITUTO CULINARIO BOULANGER PUEBLA</li>
+          <li>INSTITUTO ARNOLD GESELL</li>
+          <li>COLEGIO MARIA TERESA LOPEZ VIUDA DE TELLEZ</li>
+          <li>CENTRO DE ESTUDIO KENNEDY</li>
+          <li>COLEGIO DISCOVERY</li>
+          <li>INTITUTO D’VINCI</li>
+          <li>INSTITUTO EDUCARES</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="gobierno" class="py-5">
+      <div class="container">
+        <h2>Gobierno</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>H. AYUNTAMIENTO DE TEHUACAN</li>
+          <li>H. AYUNTAMIENTO DE COXCALTLAN</li>
+          <li>MUNICIPIO DE ZINACATEPEC</li>
+          <li>CIUDAD MODELO GOBIERNO DEL ESTADO DE PUEBLA</li>
+          <li>GOBIERNO FEDERAL</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="salud" class="py-5 bg-light">
+      <div class="container">
+        <h2>Salud</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>IMSS RED DE GUARDERIAS</li>
+          <li>CENTRO MEDICO ESPERANZA</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="energia-estaciones" class="py-5">
+      <div class="container">
+        <h2>Energía/Estaciones de servicio</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>ESTACIÓN DE SERVICIO OXI FUELL</li>
+          <li>GASOLINERA PEÑAFIEL</li>
+          <li>ESTACIÓN DE SERVICIO SOCORRO ROMERO SANCHEZ</li>
+          <li>GASOLINERA EL RIEGO</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="manufactura-industrial" class="py-5 bg-light">
+      <div class="container">
+        <h2>Manufactura/Industrial</h2>
+        <p>Aplican estos servicios:</p>
+        <ul>
+          <li><a href="proteccion-civil.html">Protección Civil</a></li>
+          <li><a href="capacitacion-dc3.html">Capacitación (DC3)</a></li>
+          <li><a href="dictamenes-inspecciones.html">Dictámenes e Inspecciones</a></li>
+          <li><a href="stps.html">Seguridad y Salud en el Trabajo (STPS)</a></li>
+          <li><a href="equipos-y-senaletica.html">Venta de Insumos y Equipamiento</a></li>
+        </ul>
+        <h3 class="mt-4">Clientes</h3>
+        <ul class="list-unstyled">
+          <li>BOXMARK LEATHER DE MEXICO S.A. DE C.V.(PROVEEDOR DE AUDI)</li>
+          <li>BACHOCO</li>
+          <li>LABORATORIO AVIMEX ASESOR DEL CORPORATIVO A NIVEL NACIONAL</li>
+          <li>MINERA SANTA MONICA IZUCAR DE MATAMOROS</li>
+          <li>MANUFACTURA, DESARROLLO DIGITAL Y PROCESOS INDUSTRIALES S.A. DE C.V.</li>
+          <li>GEOMETRIKA DE GRUPO EXCEL NOBLEZA</li>
+          <li>CONSERFLOW</li>
+          <li>GRUPO LUIN FARMACEUTICA</li>
+        </ul>
       </div>
     </section>
   </main>
 
-  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+  <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- corrige rutas de assets y añade meta descripciones
- crea hub de industrias con navegación por sector, servicios y clientes del PDF
- documenta certificaciones y registros oficiales con códigos
- lista completa de casos/clientes con filtro simple por sector

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689391e77b188332a821195c5bcc5045