### PR TITLE
Recursos (3 guías), Sobre Nosotros (PDF), Contacto (Tipo + datos), Legal (2 páginas)

### DIFF
--- a/aviso-de-privacidad.html
+++ b/aviso-de-privacidad.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Sobre Nosotros - GyG Protección Civil</title>
-  <meta name="description" content="Misión y visión de GyG. 30 años de experiencia en protección civil. Datos de contacto.">
+  <title>Aviso de Privacidad - GyG Protección Civil</title>
+  <meta name="description" content="Aviso de privacidad de GyG Protección Civil con finalidades y derechos ARCO.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,15 +39,23 @@
 
     <section class="py-5">
       <div class="container">
-        <h1>Sobre Nosotros</h1>
-        <h2 class="mt-4">Nuestra Misión</h2>
-        <p>“Crear entornos familiares y laborales más seguros a partir de la asesoría, la capacitación, la sensibilización y el suministro de equipos de seguridad en materia de protección civil, medio ambiente y la prevención de todo aquello que represente un riesgo a las personas, sus bienes y su sociedad para hacer de la seguridad un estilo de vida y no solo el cumplimiento de un requisito.”</p>
-        <h2 class="mt-4">Nuestra Visión</h2>
-        <p>“Continuar como hasta ahora siendo la empresa consultora líder en la asesoría de Protección Civil, Medio Ambiente, Prevención de Riesgos y Preservación de la Integridad de las Personas y su Entorno, así como en el suministro de equipos de seguridad con alianzas comerciales calificadas y con la aplicación de procedimientos bajo estándares nacionales e internacionales de calidad para lograr nuestra misión y satisfacer las necesidades de todos los que requieran de nuestros servicios.”</p>
-        <h2 class="mt-4">Experiencia</h2>
-        <p>Contamos con 30 años de experiencia en el ramo de la protección civil.</p>
-        <h2 class="mt-4">Contacto</h2>
-        <p>distgyg@hotmail.com · 238 1-09-22-60 · Tehuacán, Puebla.</p>
+        <h1>Aviso de Privacidad</h1>
+        <h2 class="mt-4">Responsable y datos de contacto</h2>
+        <p>GyG Protección Civil, distgyg@hotmail.com, 238 1-09-22-60, Tehuacán, Puebla.</p>
+        <h2 class="mt-4">Finalidades del tratamiento</h2>
+        <p>Los datos personales recabados se utilizarán para brindar información sobre nuestros servicios y dar seguimiento a solicitudes.</p>
+        <h2 class="mt-4">Base legal</h2>
+        <p>El tratamiento se realiza con fundamento en la relación comercial con los titulares.</p>
+        <h2 class="mt-4">Transferencias</h2>
+        <p>No aplicable.</p>
+        <h2 class="mt-4">Derechos ARCO y medios de contacto</h2>
+        <p>Para ejercer sus derechos de acceso, rectificación, cancelación u oposición, envíe un correo a distgyg@hotmail.com.</p>
+        <h2 class="mt-4">Conservación</h2>
+        <p>Los datos se conservarán únicamente el tiempo necesario para cumplir con las finalidades mencionadas.</p>
+        <h2 class="mt-4">Cambios al aviso</h2>
+        <p>Cualquier cambio a este aviso será publicado en este mismo sitio.</p>
+        <h2 class="mt-4">Vigencia</h2>
+        <p>Este aviso es vigente a partir de su última actualización.</p>
       </div>
     </section>
   </main>

--- a/contacto.html
+++ b/contacto.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Contacto - GyG Protección Civil</title>
-  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <meta name="description" content="Contáctanos: email, teléfono y ubicación. Formulario con tipos de solicitud.">
+  <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
   </style>
@@ -15,7 +16,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-gradient-dark z-index-3 py-3 sticky-top">
       <div class="container">
         <a class="navbar-brand text-white" href="index.html" rel="tooltip" title="GyG Protección Civil" data-placement="bottom">GyG Protección Civil</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Mostrar navegación">
           <span class="navbar-toggler-icon" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 30 30%27%3E%3Cpath stroke=%27rgba(255, 255, 255, 1)%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-miterlimit=%2710%27 d=%27M4 7h22M4 15h22M4 23h22%27/%3E%3C/svg%3E');"></span>
         </button>
         <div class="collapse navbar-collapse" id="navigation">
@@ -30,7 +31,7 @@
             <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="contacto.html">Contacto</a></li>
           </ul>
           <ul class="navbar-nav ms-auto">
-            <button class="btn bg-gradient-success mb-0">Contáctanos</button>
+            <li class="nav-item"><a class="btn bg-gradient-success mb-0" href="contacto.html">Contáctanos</a></li>
           </ul>
         </div>
       </div>
@@ -39,43 +40,98 @@
     <section class="py-5">
       <div class="container">
         <h1>Contacto</h1>
-        <form action="#" method="post" class="row g-3" aria-label="Formulario de contacto">
-          <div class="col-md-6">
-            <label for="tipo" class="form-label">Tipo de solicitud</label>
-            <select id="tipo" name="tipo" class="form-select" aria-label="Tipo de solicitud">
-              <option value="Diagnóstico">Diagnóstico</option>
-              <option value="Capacitación">Capacitación</option>
-              <option value="Dictámenes e Inspecciones">Dictámenes e Inspecciones</option>
-              <option value="STPS">STPS</option>
-              <option value="Equipos">Equipos</option>
-              <option value="Otro">Otro</option>
-            </select>
+        <div class="row mt-4">
+          <div class="col-md-4 mb-4">
+            <h2 class="h5">Datos de contacto</h2>
+            <ul class="list-unstyled">
+              <li><strong>Email:</strong> distgyg@hotmail.com</li>
+              <li><strong>Teléfono:</strong> 238 1-09-22-60</li>
+              <li><strong>Ubicación:</strong> Tehuacán, Puebla</li>
+            </ul>
           </div>
-          <div class="col-md-6">
-            <label for="nombre" class="form-label">Nombre</label>
-            <input type="text" id="nombre" name="nombre" class="form-control" aria-label="Nombre">
+          <div class="col-md-8">
+            <form id="contact-form" action="#" method="post" class="row g-3" novalidate>
+              <div id="form-errors" class="col-12 alert alert-danger d-none" role="alert" tabindex="-1"></div>
+              <div class="col-md-6">
+                <label for="tipo" class="form-label">Tipo de solicitud</label>
+                <select id="tipo" name="tipo" class="form-select" required aria-describedby="error-tipo">
+                  <option value="" selected disabled>Selecciona una opción</option>
+                  <option>Diagnóstico / Programa interno</option>
+                  <option>Capacitación (DC3, incendios, primeros auxilios con DEA, etc.)</option>
+                  <option>Inspecciones / Dictámenes</option>
+                  <option>STPS</option>
+                  <option>Venta de equipos</option>
+                  <option>Otro</option>
+                </select>
+                <div id="error-tipo" class="text-danger"></div>
+              </div>
+              <div class="col-md-6">
+                <label for="nombre" class="form-label">Nombre</label>
+                <input type="text" id="nombre" name="nombre" class="form-control" required aria-describedby="error-nombre">
+                <div id="error-nombre" class="text-danger"></div>
+              </div>
+              <div class="col-md-6">
+                <label for="email" class="form-label">Email</label>
+                <input type="email" id="email" name="email" class="form-control" required aria-describedby="error-email">
+                <div id="error-email" class="text-danger"></div>
+              </div>
+              <div class="col-md-6">
+                <label for="telefono" class="form-label">Teléfono</label>
+                <input type="tel" id="telefono" name="telefono" class="form-control" required inputmode="tel" autocomplete="tel" aria-describedby="error-telefono">
+                <div id="error-telefono" class="text-danger"></div>
+              </div>
+              <div class="col-12">
+                <label for="mensaje" class="form-label">Mensaje</label>
+                <textarea id="mensaje" name="mensaje" class="form-control" rows="4" required aria-describedby="error-mensaje"></textarea>
+                <div id="error-mensaje" class="text-danger"></div>
+              </div>
+              <div class="col-12">
+                <button type="submit" class="btn bg-gradient-success">Enviar</button>
+              </div>
+            </form>
           </div>
-          <div class="col-md-6">
-            <label for="email" class="form-label">Email</label>
-            <input type="email" id="email" name="email" class="form-control" aria-label="Correo electrónico">
-          </div>
-          <div class="col-md-6">
-            <label for="telefono" class="form-label">Teléfono</label>
-            <input type="tel" id="telefono" name="telefono" class="form-control" aria-label="Teléfono">
-          </div>
-          <div class="col-12">
-            <label for="mensaje" class="form-label">Mensaje</label>
-            <textarea id="mensaje" name="mensaje" class="form-control" rows="4" aria-label="Mensaje"></textarea>
-          </div>
-          <div class="col-12">
-            <button type="submit" class="btn bg-gradient-success">Enviar</button>
-          </div>
-        </form>
+        </div>
       </div>
     </section>
   </main>
 
-  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+  <footer class="footer py-3 mt-5 border-top">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-muted">© GyG Protección Civil</span>
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="aviso-de-privacidad.html">Aviso de Privacidad</a></li>
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="terminos.html">Términos y Condiciones</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="assets/js/core/bootstrap.min.js" defer></script>
+  <script>
+  (function() {
+    const form = document.getElementById('contact-form');
+    const summary = document.getElementById('form-errors');
+    form.addEventListener('submit', function (e) {
+      let errors = [];
+      ['tipo','nombre','email','telefono','mensaje'].forEach(function(id) {
+        const field = document.getElementById(id);
+        const errorEl = document.getElementById('error-' + id);
+        if (!field.value || (field.type === 'email' && !field.validity.valid)) {
+          field.setAttribute('aria-invalid', 'true');
+          errorEl.textContent = 'Campo obligatorio';
+          errors.push(field.labels[0].textContent);
+        } else {
+          field.removeAttribute('aria-invalid');
+          errorEl.textContent = '';
+        }
+      });
+      if (errors.length) {
+        e.preventDefault();
+        summary.textContent = 'Por favor corrige: ' + errors.join(', ');
+        summary.classList.remove('d-none');
+        summary.focus();
+      }
+    });
+  })();
+  </script>
 </body>
 </html>
-

--- a/recursos.html
+++ b/recursos.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>Recursos - GyG Protección Civil</title>
-  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <meta name="description" content="Recursos educativos: checklist para simulacros, señalética de evacuación y qué es DC3.">
+  <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
   </style>
@@ -15,7 +16,7 @@
     <nav class="navbar navbar-expand-lg navbar-dark bg-gradient-dark z-index-3 py-3 sticky-top">
       <div class="container">
         <a class="navbar-brand text-white" href="index.html" rel="tooltip" title="GyG Protección Civil" data-placement="bottom">GyG Protección Civil</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Mostrar navegación">
           <span class="navbar-toggler-icon" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 30 30%27%3E%3Cpath stroke=%27rgba(255, 255, 255, 1)%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-miterlimit=%2710%27 d=%27M4 7h22M4 15h22M4 23h22%27/%3E%3C/svg%3E');"></span>
         </button>
         <div class="collapse navbar-collapse" id="navigation">
@@ -30,7 +31,7 @@
             <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="contacto.html">Contacto</a></li>
           </ul>
           <ul class="navbar-nav ms-auto">
-            <button class="btn bg-gradient-success mb-0">Contáctanos</button>
+            <li class="nav-item"><a class="btn bg-gradient-success mb-0" href="contacto.html">Contáctanos</a></li>
           </ul>
         </div>
       </div>
@@ -38,13 +39,50 @@
 
     <section class="py-5">
       <div class="container">
-        <h1>Recursos</h1>
-        <p>Próximamente compartiremos guías y material de apoyo.</p>
+        <h1 class="mb-4">Recursos</h1>
+        <div class="row row-cols-1 row-cols-md-3 g-4">
+          <div class="col">
+            <div class="card h-100">
+              <div class="card-body">
+                <h2 class="h5">Checklist para simulacros</h2>
+                <p class="card-text">Pasos básicos para planear y evaluar un simulacro de manera segura.</p>
+                <a class="btn btn-link p-0" href="recursos/checklist-simulacros.html">Ver guía</a>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card h-100">
+              <div class="card-body">
+                <h2 class="h5">Señalética básica de evacuación</h2>
+                <p class="card-text">Tipos de señales preventivas e informativas para orientar al personal.</p>
+                <a class="btn btn-link p-0" href="recursos/senaletica-evacuacion.html">Ver guía</a>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card h-100">
+              <div class="card-body">
+                <h2 class="h5">¿Qué es DC3?</h2>
+                <p class="card-text">Constancia que acredita habilidades laborales ante la STPS.</p>
+                <a class="btn btn-link p-0" href="recursos/que-es-dc3.html">Ver guía</a>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </section>
   </main>
 
-  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+  <footer class="footer py-3 mt-5 border-top">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-muted">© GyG Protección Civil</span>
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="aviso-de-privacidad.html">Aviso de Privacidad</a></li>
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="terminos.html">Términos y Condiciones</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="assets/js/core/bootstrap.min.js" defer></script>
 </body>
 </html>
-

--- a/recursos/checklist-simulacros.html
+++ b/recursos/checklist-simulacros.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="es-MX">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Checklist para simulacros - GyG Protección Civil</title>
+  <meta name="description" content="Guía genérica para preparar simulacros antes, durante y después.">
+  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <style>
+    .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
+  </style>
+</head>
+<body>
+  <a class="visually-hidden-focusable" href="#contenido">Saltar al contenido principal</a>
+  <main id="contenido">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-gradient-dark z-index-3 py-3 sticky-top">
+      <div class="container">
+        <a class="navbar-brand text-white" href="../index.html" rel="tooltip" title="GyG Protección Civil" data-placement="bottom">GyG Protección Civil</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Mostrar navegación">
+          <span class="navbar-toggler-icon" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 30 30%27%3E%3Cpath stroke=%27rgba(255, 255, 255, 1)%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-miterlimit=%2710%27 d=%27M4 7h22M4 15h22M4 23h22%27/%3E%3C/svg%3E');"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navigation">
+          <ul class="navbar-nav navbar-nav-hover mx-auto">
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../index.html">Inicio</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../servicios.html">Servicios</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../industrias.html">Industrias</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../certificaciones.html">Certificaciones</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../casos.html">Casos/Clientes</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../recursos.html">Recursos</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../sobre-nosotros.html">Sobre Nosotros</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../contacto.html">Contacto</a></li>
+          </ul>
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="btn bg-gradient-success mb-0" href="../contacto.html">Contáctanos</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <section class="py-5">
+      <div class="container">
+        <h1>Checklist para simulacros</h1>
+        <p class="mt-4">Objetivo: asegurar que el simulacro se realice de forma ordenada y segura.</p>
+        <h2 class="mt-4">Antes del simulacro</h2>
+        <ul>
+          <li>Definir responsables y rutas de evacuación.</li>
+          <li>Informar al personal sobre fecha y horario.</li>
+          <li>Revisar equipo de emergencia y señalización.</li>
+        </ul>
+        <h2 class="mt-4">Durante el simulacro</h2>
+        <ul>
+          <li>Iniciar la alarma y dirigir la evacuación.</li>
+          <li>Supervisar que se sigan las rutas establecidas.</li>
+          <li>Registrar tiempos de salida y llegada a puntos de reunión.</li>
+        </ul>
+        <h2 class="mt-4">Después del simulacro</h2>
+        <ul>
+          <li>Verificar asistencia en el punto de reunión.</li>
+          <li>Identificar áreas de mejora y registrar observaciones.</li>
+          <li>Compartir resultados con el personal.</li>
+        </ul>
+        <p class="mt-4"><a class="btn bg-gradient-success" href="../contacto.html?tipo=inspecciones">Solicitar simulacro</a></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer py-3 mt-5 border-top">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-muted">© GyG Protección Civil</span>
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../aviso-de-privacidad.html">Aviso de Privacidad</a></li>
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../terminos.html">Términos y Condiciones</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+</body>
+</html>

--- a/recursos/que-es-dc3.html
+++ b/recursos/que-es-dc3.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="es-MX">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>¿Qué es DC3? - GyG Protección Civil</title>
+  <meta name="description" content="Constancia de habilidades laborales; GyG expide DC3 con validez ante STPS y Protección Civil.">
+  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <style>
+    .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
+  </style>
+</head>
+<body>
+  <a class="visually-hidden-focusable" href="#contenido">Saltar al contenido principal</a>
+  <main id="contenido">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-gradient-dark z-index-3 py-3 sticky-top">
+      <div class="container">
+        <a class="navbar-brand text-white" href="../index.html" rel="tooltip" title="GyG Protección Civil" data-placement="bottom">GyG Protección Civil</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Mostrar navegación">
+          <span class="navbar-toggler-icon" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 30 30%27%3E%3Cpath stroke=%27rgba(255, 255, 255, 1)%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-miterlimit=%2710%27 d=%27M4 7h22M4 15h22M4 23h22%27/%3E%3C/svg%3E');"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navigation">
+          <ul class="navbar-nav navbar-nav-hover mx-auto">
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../index.html">Inicio</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../servicios.html">Servicios</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../industrias.html">Industrias</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../certificaciones.html">Certificaciones</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../casos.html">Casos/Clientes</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../recursos.html">Recursos</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../sobre-nosotros.html">Sobre Nosotros</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../contacto.html">Contacto</a></li>
+          </ul>
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="btn bg-gradient-success mb-0" href="../contacto.html">Contáctanos</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <section class="py-5">
+      <div class="container">
+        <h1>¿Qué es DC3?</h1>
+        <p class="mt-4">El DC3 es una constancia que certifica habilidades laborales. GyG expide constancias DC3 con validez ante la STPS y Protección Civil.</p>
+        <p class="mt-4"><a class="btn bg-gradient-success" href="../contacto.html?tipo=capacitacion">Cotizar capacitación DC3</a></p>
+        <h2 class="mt-5">Temas relacionados</h2>
+        <ul>
+          <li><a href="../capacitacion-dc3.html">Capacitación DC3</a></li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer py-3 mt-5 border-top">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-muted">© GyG Protección Civil</span>
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../aviso-de-privacidad.html">Aviso de Privacidad</a></li>
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../terminos.html">Términos y Condiciones</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+</body>
+</html>

--- a/recursos/senaletica-evacuacion.html
+++ b/recursos/senaletica-evacuacion.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es-MX">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Señalética básica de evacuación - GyG Protección Civil</title>
+  <meta name="description" content="Tipos de señales preventivas, informativas, restrictivas y rutas de evacuación.">
+  <link href="../assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
+  <style>
+    .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
+  </style>
+</head>
+<body>
+  <a class="visually-hidden-focusable" href="#contenido">Saltar al contenido principal</a>
+  <main id="contenido">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-gradient-dark z-index-3 py-3 sticky-top">
+      <div class="container">
+        <a class="navbar-brand text-white" href="../index.html" rel="tooltip" title="GyG Protección Civil" data-placement="bottom">GyG Protección Civil</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navigation" aria-controls="navigation" aria-expanded="false" aria-label="Mostrar navegación">
+          <span class="navbar-toggler-icon" style="background-image: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 30 30%27%3E%3Cpath stroke=%27rgba(255, 255, 255, 1)%27 stroke-width=%272%27 stroke-linecap=%27round%27 stroke-miterlimit=%2710%27 d=%27M4 7h22M4 15h22M4 23h22%27/%3E%3C/svg%3E');"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navigation">
+          <ul class="navbar-nav navbar-nav-hover mx-auto">
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../index.html">Inicio</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../servicios.html">Servicios</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../industrias.html">Industrias</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../certificaciones.html">Certificaciones</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../casos.html">Casos/Clientes</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../recursos.html">Recursos</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../sobre-nosotros.html">Sobre Nosotros</a></li>
+            <li class="nav-item px-3"><a class="nav-link text-white opacity-8" href="../contacto.html">Contacto</a></li>
+          </ul>
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="btn bg-gradient-success mb-0" href="../contacto.html">Contáctanos</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <section class="py-5">
+      <div class="container">
+        <h1>Señalética básica de evacuación</h1>
+        <h2 class="mt-4">Señales preventivas</h2>
+        <p>Alertan sobre la presencia de un riesgo para que las personas actúen con precaución.</p>
+        <h2 class="mt-4">Señales informativas</h2>
+        <p>Brindan datos útiles como salidas de emergencia, ubicación de extintores o primeros auxilios.</p>
+        <h2 class="mt-4">Señales restrictivas</h2>
+        <p>Indican acciones prohibidas o limitaciones en determinadas áreas.</p>
+        <h2 class="mt-4">Rutas de evacuación</h2>
+        <p>Muestran el camino seguro hacia los puntos de reunión durante una emergencia.</p>
+        <p class="mt-4"><a class="btn bg-gradient-success" href="../contacto.html?tipo=equipos">Solicitar señalización</a></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer py-3 mt-5 border-top">
+    <div class="container d-flex flex-wrap justify-content-between align-items-center">
+      <span class="text-muted">© GyG Protección Civil</span>
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../aviso-de-privacidad.html">Aviso de Privacidad</a></li>
+        <li class="nav-item"><a class="nav-link px-2 text-muted" href="../terminos.html">Términos y Condiciones</a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="../assets/js/core/bootstrap.min.js" defer></script>
+</body>
+</html>

--- a/terminos.html
+++ b/terminos.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Sobre Nosotros - GyG Protección Civil</title>
-  <meta name="description" content="Misión y visión de GyG. 30 años de experiencia en protección civil. Datos de contacto.">
+  <title>Términos y Condiciones - GyG Protección Civil</title>
+  <meta name="description" content="Términos y condiciones de uso del sitio de GyG Protección Civil.">
   <link href="assets/css/soft-design-system.css?v=1.0.9" rel="stylesheet" />
   <style>
     .navbar-nav .nav-link:focus-visible { outline: 2px dashed #fff; outline-offset:2px; }
@@ -39,15 +39,21 @@
 
     <section class="py-5">
       <div class="container">
-        <h1>Sobre Nosotros</h1>
-        <h2 class="mt-4">Nuestra Misión</h2>
-        <p>“Crear entornos familiares y laborales más seguros a partir de la asesoría, la capacitación, la sensibilización y el suministro de equipos de seguridad en materia de protección civil, medio ambiente y la prevención de todo aquello que represente un riesgo a las personas, sus bienes y su sociedad para hacer de la seguridad un estilo de vida y no solo el cumplimiento de un requisito.”</p>
-        <h2 class="mt-4">Nuestra Visión</h2>
-        <p>“Continuar como hasta ahora siendo la empresa consultora líder en la asesoría de Protección Civil, Medio Ambiente, Prevención de Riesgos y Preservación de la Integridad de las Personas y su Entorno, así como en el suministro de equipos de seguridad con alianzas comerciales calificadas y con la aplicación de procedimientos bajo estándares nacionales e internacionales de calidad para lograr nuestra misión y satisfacer las necesidades de todos los que requieran de nuestros servicios.”</p>
-        <h2 class="mt-4">Experiencia</h2>
-        <p>Contamos con 30 años de experiencia en el ramo de la protección civil.</p>
+        <h1>Términos y Condiciones de Uso</h1>
+        <h2 class="mt-4">Aceptación</h2>
+        <p>Al acceder a este sitio aceptas los presentes términos y condiciones.</p>
+        <h2 class="mt-4">Uso permitido</h2>
+        <p>El contenido de este sitio se proporciona para fines informativos y no debe utilizarse con propósitos ilícitos.</p>
+        <h2 class="mt-4">Propiedad intelectual</h2>
+        <p>Los contenidos del sitio pertenecen a GyG Protección Civil o a sus respectivos titulares.</p>
+        <h2 class="mt-4">Limitación de responsabilidad</h2>
+        <p>GyG Protección Civil no se responsabiliza por el uso que se haga de la información publicada.</p>
+        <h2 class="mt-4">Enlaces externos</h2>
+        <p>Este sitio puede contener enlaces a sitios externos sobre los que no tenemos control.</p>
+        <h2 class="mt-4">Modificaciones</h2>
+        <p>Los términos pueden modificarse en cualquier momento y las actualizaciones se publicarán en este sitio.</p>
         <h2 class="mt-4">Contacto</h2>
-        <p>distgyg@hotmail.com · 238 1-09-22-60 · Tehuacán, Puebla.</p>
+        <p>Para cualquier duda sobre estos términos, escribe a distgyg@hotmail.com.</p>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Reestructuré `recursos.html` como hub con tres guías genéricas y agregué páginas detalladas con CTA hacia contacto.
- Actualicé `sobre-nosotros.html` con la misión, visión, experiencia y datos de contacto citados del PDF.
- Mejoré `contacto.html` añadiendo bloque de datos, nuevas opciones de tipo y validación accesible.
- Creé `aviso-de-privacidad.html` y `terminos.html` y enlacé ambas páginas desde el pie de página.

## Testing
- `npm test` *(falla: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6893958cb0e883329e33fa9c7a903df6